### PR TITLE
Fixed docstring and behavior when arguments are lists instead of sets.

### DIFF
--- a/quine_mccluskey/qm.py
+++ b/quine_mccluskey/qm.py
@@ -124,8 +124,8 @@ class QuineMcCluskey:
             self.n_bits = int(math.ceil(math.log(max(terms) + 1, 2)))
 
         # Generate the sets of ones and dontcares
-        ones = set(self.__num2str(i) for i in ones)
-        dc = set(self.__num2str(i) for i in dc)
+        ones = [self.__num2str(i) for i in ones]
+        dc = [self.__num2str(i) for i in dc]
 
         return self.simplify_los(ones, dc)
 
@@ -139,7 +139,7 @@ class QuineMcCluskey:
             function is '1', e.g. ['0001', '0010', '0110', '1000', '1111'].
 
         Kwargs:
-            dc: (list of str)set of strings that define the don't care
+            dc: (list of str): list of strings that define the don't care
             combinations.
 
         Returns:
@@ -174,7 +174,7 @@ class QuineMcCluskey:
         self.profile_xor = 0    # number of comparisons (for profiling)
         self.profile_xnor = 0   # number of comparisons (for profiling)
 
-        terms = ones | dc
+        terms = set(ones) | set(dc)
         if len(terms) == 0:
             return None
 


### PR DESCRIPTION
Before, the docstring for `simplify_los` said that `dc` is a set of
strings. This is in contrast to the default parameter value, which is
`[]`. I think the intended behavior is for both `ones` and `dc` to be
lists (as the "l" in the function name probably implies).

In `simplify`, `simplify_los` is called with sets as arguments. I
changed this so it's a list as intended.

Moreover, if we use `simplify_los` accordingly and pass lists as
arguments, we get an error because set union is used in `terms = ones | dc`.

I fixed this by creating sets from those lists there instead.